### PR TITLE
feat(validation): unique fragment names

### DIFF
--- a/src/GraphQLCore/Language/GraphQLAstVisitor.cs
+++ b/src/GraphQLCore/Language/GraphQLAstVisitor.cs
@@ -241,7 +241,8 @@
                 if (definition.Kind == ASTNodeKind.FragmentDefinition)
                 {
                     var fragment = (GraphQLFragmentDefinition)definition;
-                    this.Fragments.Add(fragment.Name.Value, fragment);
+                    if (!this.Fragments.ContainsKey(fragment.Name.Value))
+                        this.Fragments.Add(fragment.Name.Value, fragment);
                 }
             }
 

--- a/src/GraphQLCore/Validation/Rules/UniqueFragmentNames.cs
+++ b/src/GraphQLCore/Validation/Rules/UniqueFragmentNames.cs
@@ -1,0 +1,18 @@
+﻿namespace GraphQLCore.Validation.Rules
+{
+    using Exceptions;
+    using Language.AST;
+    using System.Collections.Generic;
+    using Type;
+
+    public class UniqueFragmentNames : IValidationRule
+    {
+        public IEnumerable<GraphQLException> Validate(GraphQLDocument document, IGraphQLSchema schema)
+        {
+            var visitor = new UniqueFragmentNamesVisitor(schema);
+            visitor.Visit(document);
+
+            return visitor.Errors;
+        }
+    }
+}

--- a/src/GraphQLCore/Validation/Rules/UniqueFragmentNamesVisitor.cs
+++ b/src/GraphQLCore/Validation/Rules/UniqueFragmentNamesVisitor.cs
@@ -1,0 +1,36 @@
+﻿namespace GraphQLCore.Validation.Rules
+{
+    using Exceptions;
+    using Language.AST;
+    using Language;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Type;
+
+    public class UniqueFragmentNamesVisitor : ValidationASTVisitor
+    {
+        public UniqueFragmentNamesVisitor(IGraphQLSchema schema) : base(schema)
+        {
+            this.Errors = new List<GraphQLException>();
+        }
+
+        public List<GraphQLException> Errors { get; private set; }
+
+        public override void Visit(GraphQLDocument ast)
+        {
+            this.Errors = ast.Definitions
+                .Where(x => x.Kind == ASTNodeKind.FragmentDefinition)
+                .Select(x => ((GraphQLFragmentDefinition)x).Name.Value)
+                .GroupBy(x => x)
+                .Where(g => g.Count() > 1)
+                .Select(x => x.Key)
+                .Select(this.GetFragmentNameError)
+                .ToList();
+        }
+
+        private GraphQLException GetFragmentNameError(string variableName)
+        {
+            return new GraphQLException($"There can be only one fragment named \"{variableName}\".");
+        }
+    }
+}

--- a/src/GraphQLCore/Validation/VariableUsagesProvider.cs
+++ b/src/GraphQLCore/Validation/VariableUsagesProvider.cs
@@ -57,7 +57,8 @@
                 if (definition.Kind == ASTNodeKind.FragmentDefinition)
                 {
                     var fragment = (GraphQLFragmentDefinition)definition;
-                    fragments.Add(fragment.Name.Value, fragment);
+                    if (!fragments.ContainsKey(fragment.Name.Value))
+                        fragments.Add(fragment.Name.Value, fragment);
                 }
             }
 

--- a/test/GraphQLCore.Tests/Validation/UniqueFragmentNamesTest.cs
+++ b/test/GraphQLCore.Tests/Validation/UniqueFragmentNamesTest.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+
+namespace GraphQLCore.Tests.Validation
+{
+    using NUnit.Framework;
+    using Exceptions;
+    using System.Collections.Generic;
+    using GraphQLCore.Validation.Rules;
+
+    [TestFixture]
+    public class UniqueFragmentNamesTest : ValidationTestBase
+    {
+        [Test]
+        public void UniqueFragmentNames()
+        {
+            var errors = this.Validate(@"
+                fragment Foo on SimpleObjectType {
+                    booleanField
+                }
+                fragment Bar on SimpleObjectType {
+                    booleanField
+                }
+            ");
+            Assert.IsEmpty(errors);
+        }
+
+        [Test]
+        public void DuplicateFragmentNames()
+        {
+            var errors = this.Validate(@"
+                fragment Foo on SimpleObjectType {
+                    booleanField
+                }
+                fragment Foo on SimpleObjectType {
+                    booleanField
+                }
+            ");
+            Assert.AreEqual("There can be only one fragment named \"Foo\".", errors.ElementAt(0).Message);
+            Assert.AreEqual(1, errors.Count());
+        }
+    }
+}

--- a/test/GraphQLCore.Tests/Validation/ValidationTestBase.cs
+++ b/test/GraphQLCore.Tests/Validation/ValidationTestBase.cs
@@ -1,9 +1,9 @@
 ﻿namespace GraphQLCore.Tests.Validation
 {
-    using GraphQLCore.Exceptions;
+    using Exceptions;
     using GraphQLCore.Language;
     using GraphQLCore.Language.AST;
-    using GraphQLCore.Tests.Schemas;
+    using Schemas;
     using GraphQLCore.Validation;
     using GraphQLCore.Validation.Rules;
     using NUnit.Framework;
@@ -38,6 +38,7 @@
                     new UniqueArguments(),
                     new UniqueVariableNames(),
                     new UniqueOperationNames(),
+                    new UniqueFragmentNames(),
                     new KnownTypeNames(),
                     new PossibleFragmentSpreads(),
                     new VariablesAreInputTypes(),


### PR DESCRIPTION
Hello,
There is maybe one weird thing in this PR and that is I needed to write my own `Validate` method instead of using one from the base class because I always got an exception when trying to parse query with two same named fragments as they are stored in definitions dictionary where key is their name. Obviously that raised an exception so I needed a way around that. Maybe I am missing something as I am not that comfortable with code base yet. It will be nice to solve this before merging so I stick with style of other validations.
