### PR TITLE
fix(travis): change of CLI_VERSION environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 sudo: required
 dist: trusty
 env:
-  - CLI_VERSION=latest
+  - CLI_VERSION="1.0.0-preview3-003223"
 addons:
   apt:
     packages:


### PR DESCRIPTION
This fixes Travis CI builds. Latest CLI version is not compatible with .NET Core 1.0.0.