### PR TITLE
fix(Execution): object variables

### DIFF
--- a/src/GraphQLCore/Execution/VariableResolver.cs
+++ b/src/GraphQLCore/Execution/VariableResolver.cs
@@ -61,6 +61,9 @@ namespace GraphQLCore.Execution
 
         public object TranslatePerDefinition(object inputObject, GraphQLBaseType typeDefinition)
         {
+            if (typeDefinition is Type.GraphQLNonNullType)
+                return this.TranslatePerDefinition(inputObject, ((Type.GraphQLNonNullType)typeDefinition).UnderlyingNullableType);
+
             if (typeDefinition is GraphQLInputObjectType)
                 return this.CreateObjectFromDynamic((GraphQLInputObjectType)typeDefinition, (ExpandoObject)inputObject);
 

--- a/src/GraphQLCore/Type/GraphQLList.cs
+++ b/src/GraphQLCore/Type/GraphQLList.cs
@@ -27,6 +27,9 @@
 
         public override object GetFromAst(GraphQLValue astValue, ISchemaRepository schemaRepository)
         {
+            if (astValue.Kind == ASTNodeKind.Variable)
+                return null;
+
             if (!(this.MemberType is GraphQLInputType))
                 return null;
 

--- a/test/GraphQLCore.Tests/Execution/ExecutionContect_Variables.cs
+++ b/test/GraphQLCore.Tests/Execution/ExecutionContect_Variables.cs
@@ -272,18 +272,36 @@
         [Test]
         public void Execute_WithNonNullObjectVariable_ParsesAndReturnsCorrectValue()
         {
-            var query = @"mutation getStringListArg($complicatedObjectArgVar: ComplicatedInputObjectType!) {
-                            insertInputObject(inputObject: $complicatedObjectArgVar) {
-                                stringField
-                            }
-                        }";
+            var query = @"
+            mutation getStringListArg($complicatedObjectArgVar: ComplicatedInputObjectType!) {
+                insertInputObject(inputObject: $complicatedObjectArgVar) {
+                    stringField
+                }
+            }";
 
             var result = this.schema.Execute(query, variables);
             var stringField = result.insertInputObject.stringField;
 
             Assert.AreEqual("sample", stringField);
         }
-        //ComplicatedInputObjectType
+
+        [Test]
+        public void Execute_WithListVariableInObjectArgs_ParsesAndReturnsCorrectValue()
+        {
+            var query = @"
+            query getStringListField($stringListArgVar: [String]) {
+                insertInputObject(inputObject: {
+                    stringListField: $stringListArgVar
+                }) {
+                    stringListField
+                }
+            }";
+
+            var result = this.schema.Execute(query, variables);
+            var stringListField = result.insertInputObject.stringListField;
+
+            Assert.AreEqual(new string[] { "a", "b", "c" }, stringListField);
+        }
 
         [SetUp]
         public void SetUp()

--- a/test/GraphQLCore.Tests/Execution/ExecutionContect_Variables.cs
+++ b/test/GraphQLCore.Tests/Execution/ExecutionContect_Variables.cs
@@ -269,6 +269,22 @@
             Assert.AreEqual("c", stringListField.ElementAt(2));
         }
 
+        [Test]
+        public void Execute_WithNonNullObjectVariable_ParsesAndReturnsCorrectValue()
+        {
+            var query = @"mutation getStringListArg($complicatedObjectArgVar: ComplicatedInputObjectType!) {
+                            insertInputObject(inputObject: $complicatedObjectArgVar) {
+                                stringField
+                            }
+                        }";
+
+            var result = this.schema.Execute(query, variables);
+            var stringField = result.insertInputObject.stringField;
+
+            Assert.AreEqual("sample", stringField);
+        }
+        //ComplicatedInputObjectType
+
         [SetUp]
         public void SetUp()
         {


### PR DESCRIPTION
This fixes two bugs with variables: non null object variables and list variables in object arguments. These threw an exception or were cast to null.