### PR TITLE
fix(Language): GraphQLValue string representations

### DIFF
--- a/src/GraphQLCore/Language/AST/GraphQLListValue.cs
+++ b/src/GraphQLCore/Language/AST/GraphQLListValue.cs
@@ -11,8 +11,6 @@
             this.kindField = kind;
         }
 
-        public string AstValue { get; set; }
-
         public override ASTNodeKind Kind
         {
             get
@@ -25,7 +23,9 @@
 
         public override string ToString()
         {
-            return this.AstValue;
+            var values = string.Join(", ", this.Values);
+
+            return $"[{values}]";
         }
     }
 }

--- a/src/GraphQLCore/Language/AST/GraphQLNullValue.cs
+++ b/src/GraphQLCore/Language/AST/GraphQLNullValue.cs
@@ -9,5 +9,10 @@
                 return ASTNodeKind.NullValue;
             }
         }
+
+        public override string ToString()
+        {
+            return "null";
+        }
     }
 }

--- a/src/GraphQLCore/Language/AST/GraphQLObjectValue.cs
+++ b/src/GraphQLCore/Language/AST/GraphQLObjectValue.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Generic;
-
-namespace GraphQLCore.Language.AST
+﻿namespace GraphQLCore.Language.AST
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     public class GraphQLObjectValue : GraphQLValue
     {
         public IEnumerable<GraphQLObjectField> Fields { get; set; }
@@ -12,6 +13,14 @@ namespace GraphQLCore.Language.AST
             {
                 return ASTNodeKind.ObjectValue;
             }
+        }
+
+        public override string ToString()
+        {
+            var serializedFields = this.Fields.Select(e => $"{e.Name.Value}: {e.Value}");
+            var serializedObject = string.Join(", ", serializedFields);
+
+            return $"{{{serializedObject}}}";
         }
     }
 }

--- a/src/GraphQLCore/Language/ParserContext.cs
+++ b/src/GraphQLCore/Language/ParserContext.cs
@@ -562,8 +562,7 @@
             return new GraphQLListValue(ASTNodeKind.ListValue)
             {
                 Values = this.Any(TokenKind.BRACKET_L, isConstant ? constant : value, TokenKind.BRACKET_R),
-                Location = this.GetLocation(start),
-                AstValue = this.source.Body.Substring(start, this.currentToken.End - start - 1)
+                Location = this.GetLocation(start)
             };
         }
 

--- a/test/GraphQLCore.Tests/Language/ParserTests.cs
+++ b/test/GraphQLCore.Tests/Language/ParserTests.cs
@@ -141,6 +141,28 @@
             new Parser(new Lexer()).Parse(new Source("{ field(complex: { a: { b: [ $var ] } }) }"));
         }
 
+        [Test]
+        public void Parse_ListValues_ReturnsCorrectString()
+        {
+            var document = new Parser(new Lexer()).Parse(new Source("{ field(a: [ [ 1, 2 ], 2 , [ 1, 2, 3] ] ) }"));
+            var field = (GraphQLFieldSelection)GetSingleSelection(document);
+
+            var result = (GraphQLListValue)field.Arguments.Single().Value;
+
+            Assert.AreEqual("[[1, 2], 2, [1, 2, 3]]", result.ToString());
+        }
+
+        [Test]
+        public void Parse_NullAndObjectListValues_ReturnsCorrectString()
+        {
+            var document = new Parser(new Lexer()).Parse(new Source("{ field(a: [[], [[[null], { a: 1, b: 8}]], []]) }"));
+            var field = (GraphQLFieldSelection)GetSingleSelection(document);
+
+            var result = (GraphQLListValue)field.Arguments.Single().Value;
+
+            Assert.AreEqual("[[], [[[null], {a: 1, b: 8}]], []]", result.ToString());
+        }
+
         private static GraphQLOperationDefinition GetSingleOperationDefinition(GraphQLDocument document)
         {
             return ((GraphQLOperationDefinition)document.Definitions.Single());

--- a/test/GraphQLCore.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
+++ b/test/GraphQLCore.Tests/Validation/ArgumentsOfCorrectTypeTests.cs
@@ -549,7 +549,7 @@
             }
             ");
 
-            Assert.AreEqual("Argument \"inputObject\" has invalid value GraphQLCore.Language.AST.GraphQLObjectValue.\nIn field \"intField\": Expected type \"Int\", found \"aaa\".",
+            Assert.AreEqual("Argument \"inputObject\" has invalid value {nonNullIntField: 0, intField: \"aaa\"}.\nIn field \"intField\": Expected type \"Int\", found \"aaa\".",
                 errors.Single().Message);
         }
 
@@ -567,7 +567,7 @@
             }
             ");
 
-            Assert.AreEqual("Argument \"inputObject\" has invalid value GraphQLCore.Language.AST.GraphQLObjectValue.\nIn field \"stringListField\": In element #1: Expected type \"String\", found 1.\nIn field \"stringListField\": In element #3: Expected type \"String\", found [8, 5, 4].",
+            Assert.AreEqual("Argument \"inputObject\" has invalid value {nonNullIntField: 0, stringListField: [null, 1, \"3\", [8, 5, 4]]}.\nIn field \"stringListField\": In element #1: Expected type \"String\", found 1.\nIn field \"stringListField\": In element #3: Expected type \"String\", found [8, 5, 4].",
                 errors.Single().Message);
         }
 
@@ -589,7 +589,7 @@
             }
             ");
 
-            Assert.AreEqual("Argument \"inputObject\" has invalid value GraphQLCore.Language.AST.GraphQLObjectValue.\nIn field \"nested\": In field \"nonNullIntField\": Expected type \"Int!\", found null.",
+            Assert.AreEqual("Argument \"inputObject\" has invalid value {nonNullIntField: 0, nested: {nonNullIntField: null}}.\nIn field \"nested\": In field \"nonNullIntField\": Expected type \"Int!\", found null.",
                 errors.Single().Message);
         }
     }


### PR DESCRIPTION
This PR improves GraphQL messages so they actually return value of GraphQLValue instead of returning just the type name.